### PR TITLE
Approx quantile bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ val data = assembler
 /**
   * Train the model
   */
- 
+
+val contamination = 0.1
 val isolationForest = new IsolationForest()
   .setNumEstimators(100)
   .setBootstrap(false)
@@ -185,15 +186,16 @@ val isolationForest = new IsolationForest()
   .setFeaturesCol("features")
   .setPredictionCol("predictedLabel")
   .setScoreCol("outlierScore")
-  .setContamination(0.1)
+  .setContamination(contamination)
+  .setContaminationError(0.01 * contamination)
   .setRandomSeed(1)
- 
+
 val isolationForestModel = isolationForest.fit(data)
  
 /**
   * Score the training data
   */
- 
+
 val dataWithScores = isolationForestModel.transform(data)
 
 // scala> dataWithScores.printSchema

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ build.gradle file before building.
 
 ### Add an isolation-forest dependency to your project
 
-Artifacts (built with Scala 2.11.8 and Spark 2.3.0) for this project are
-[available on Bintray](https://bintray.com/beta/#/linkedin/maven/isolation-forest).
+Please check [Bintray](https://bintray.com/beta/#/linkedin/maven/isolation-forest) for the latest
+artifact versions (built with Scala 2.11.8 and Spark 2.3.0).
 
 #### Gradle example
 
@@ -64,7 +64,7 @@ Second, add the isolation-forest dependency to the module-level build.gradle fil
 
 ```
 dependencies {
-    compile 'com.linkedin.isolation-forest:isolation-forest_2.11:0.2.2'
+    compile 'com.linkedin.isolation-forest:isolation-forest_2.11:0.3.0'
 }
 ```
 
@@ -114,23 +114,24 @@ Second, declare the isolation-forest dependency in your project's pom.xml file.
 <dependency>
   <groupId>com.linkedin.isolation-forest</groupId>
   <artifactId>isolation-forest_2.11</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 
 ### Model parameters
 
-| Parameter     | Default Value    | Description                                                                                                                                                                                                          |
-|---------------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| numEstimators | 100              | The number of trees in the ensemble.                                                                                                                                                                                 |
-| maxSamples    | 256              | The number of samples used to train each tree. If this value is between 0.0 and 1.0, then it is treated as a fraction. If it is >1.0, then it is treated as a count.                                                 |
-| contamination | 0.0              | The fraction of outliers in the training data set. If this is set to 0.0, it speeds up the training and all predicted labels will be false. The model and outlier scores are otherwise unaffected by this parameter. |
-| maxFeatures   | 1.0              | The number of features used to train each tree. If this value is between 0.0 and 1.0, then it is treated as a fraction. If it is >1.0, then it is treated as a count.                                                |
-| bootstrap     | false            | If true, draw sample for each tree with replacement. If false, do not sample with replacement.                                                                                                                       |
-| randomSeed    | 1                | The seed used for the random number generator.                                                                                                                                                                       |
-| featuresCol   | "features"       | The feature vector. This column must exist in the input DataFrame for training and scoring.                                                                                                                          |
-| predictionCol | "predictedLabel" | The predicted label. This column is appended to the input DataFrame upon scoring.                                                                                                                                    |
-| scoreCol      | "outlierScore"   | The outlier score. This column is appended to the input DataFrame upon scoring.          
+| Parameter          | Default Value    | Description                                                                                                                                                                                                                                                                                                                                                                          |
+|--------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| numEstimators      | 100              | The number of trees in the ensemble.                                                                                                                                                                                                                                                                                                                                                 |
+| maxSamples         | 256              | The number of samples used to train each tree. If this value is between 0.0 and 1.0, then it is treated as a fraction. If it is >1.0, then it is treated as a count.                                                                                                                                                                                                                 |
+| contamination      | 0.0              | The fraction of outliers in the training data set. If this is set to 0.0, it speeds up the training and all predicted labels will be false. The model and outlier scores are otherwise unaffected by this parameter.                                                                                                                                                                 |
+| contaminationError | 0.0              | The error allowed when calculating the threshold required to achieve the specified contamination fraction. The default is 0.0, which forces an exact calculation of the threshold. The exact calculation is slow and can fail for large datasets. If there are issues with the exact calculation, a good choice for this parameter is often 1% of the specified contamination value. |
+| maxFeatures        | 1.0              | The number of features used to train each tree. If this value is between 0.0 and 1.0, then it is treated as a fraction. If it is >1.0, then it is treated as a count.                                                                                                                                                                                                                |
+| bootstrap          | false            | If true, draw sample for each tree with replacement. If false, do not sample with replacement.                                                                                                                                                                                                                                                                                       |
+| randomSeed         | 1                | The seed used for the random number generator.                                                                                                                                                                                                                                                                                                                                       |
+| featuresCol        | "features"       | The feature vector. This column must exist in the input DataFrame for training and scoring.                                                                                                                                                                                                                                                                                          |
+| predictionCol      | "predictedLabel" | The predicted label. This column is appended to the input DataFrame upon scoring.                                                                                                                                                                                                                                                                                                    |
+| scoreCol           | "outlierScore"   | The outlier score. This column is appended to the input DataFrame upon scoring.                                                                                                                                                                                                                                                                                                      |
 
 ### Training and scoring
 

--- a/isolation-forest/src/main/scala/com/linkedin/relevance/isolationforest/IsolationForestParams.scala
+++ b/isolation-forest/src/main/scala/com/linkedin/relevance/isolationforest/IsolationForestParams.scala
@@ -37,6 +37,16 @@ trait IsolationForestParams extends Params {
   def setBootstrap(value: Boolean): this.type = set(bootstrap, value)
   final def getBootstrap: Boolean = $(bootstrap)
 
+  final val contaminationError = new DoubleParam(this, "contaminationError", "The error" +
+    " allowed when calculating the threshold required to achieve the specified contamination" +
+    " fraction. The default is 0.0, which forces an exact calculation of the threshold. The" +
+    " exact calculation is slow and can fail for large datasets. If there are issues with the" +
+    " exact calculation, a good choice for this parameter is often 1% of the specified" +
+    " contamination value.",
+    ParamValidators.inRange(0.0, 1, lowerInclusive = true, upperInclusive = true))
+  def setContaminationError(value: Double): this.type = set(contaminationError, value)
+  final def getContaminationError: Double = $(contaminationError)
+
   final val randomSeed = new LongParam(this, "randomSeed", "The seed used for the random" +
     " number generator.",  ParamValidators.gt(0.0))
   def setRandomSeed(value: Long): this.type = set(randomSeed, value)
@@ -58,6 +68,7 @@ trait IsolationForestParams extends Params {
     numEstimators -> 100,
     maxSamples -> 256,
     contamination -> 0.0,
+    contaminationError -> 0.0,
     maxFeatures -> 1.0,
     bootstrap -> false,
     randomSeed -> 1,

--- a/isolation-forest/src/main/scala/com/linkedin/relevance/isolationforest/Utils.scala
+++ b/isolation-forest/src/main/scala/com/linkedin/relevance/isolationforest/Utils.scala
@@ -7,6 +7,7 @@ package com.linkedin.relevance.isolationforest
 private[isolationforest] object Utils extends Serializable {
 
   case class DataPoint(features: Array[Float])
+  case class OutlierScore(score: Double)
 
   val EulerConstant = 0.5772156649f
 

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=0.2.3
+version=0.3.0
 previousVersion=0.2.2


### PR DESCRIPTION
Fixed the rare unexpected behavior reported here https://github.com/linkedin/isolation-forest/issues/3 that was due to an issue with Spark's approxQuantile method.

I made two changes to work around the unexpected approxQuantile behavior.

1) The isolation forest model now accepts a contaminationError parameter, which allows the user to set approxQuantile's relativeError parameter. The default value is now 0.0, which forces an exact calculation.

2) The isolation forest model now calculates the observed contamination after training a model and compares it to the expected contamination set via model parameters. If the deviation is unexpectedly large, a warning issued.

I also added a new unit test to validate the new relativeError = 0.0 case.

**Testing done:**

The build passes: https://travis-ci.org/linkedin/isolation-forest/builds/591787128

If the old (inflexible) contaminationError value is used, I verified a warning message is now displayed in the case reported in issue #3.

```
val vectorIndexerModel = vectorIndexer.fit(dfCastImputedAssembled)
val dfCastImputedAssembledIndexed = vectorIndexerModel.transform(dfCastImputedAssembled)

val isolationForest05 = new IsolationForest()
isolationForest05.setNumEstimators(100)
isolationForest05.setContamination(0.05)
isolationForest05.setFeaturesCol("indexedFeatures")
isolationForest05.setContaminationError(0.05 * 0.01)

val isolationForestModel05 = isolationForest05.fit(dfCastImputedAssembledIndexed)
val scores05 = isolationForestModel05.transform(dfCastImputedAssembledIndexed)
```

```
2019-09-30 18:29:19 WARN  IsolationForest:66 - Observed contamination is 0.001430615164520744, which is outside of the expected bounds of 0.1 +/- 0.001.
```

```
scala> scores05.agg(sum("predictedLabel")).show()
+-------------------+
|sum(predictedLabel)|
+-------------------+
|               35.0|
+-------------------+


scala> scores10.agg(sum("predictedLabel")).show()
+-------------------+
|sum(predictedLabel)|
+-------------------+
|                1.0|
+-------------------+
```
The scores10 case is wrong and should be ~70.

I also verified that if the new default is used (contaminationError = 0.0), the model does not throw a warning message and correctly calculates the threshold for the case reported in issue #3.

```
val isolationForest05 = new IsolationForest()
isolationForest05.setNumEstimators(100)
isolationForest05.setContamination(0.05)
isolationForest05.setFeaturesCol("indexedFeatures")
// isolationForest05.setContaminationError(0.05 * 0.01)

val isolationForestModel05 = isolationForest05.fit(dfCastImputedAssembledIndexed)
val scores05 = isolationForestModel05.transform(dfCastImputedAssembledIndexed)

val isolationForest10 = new IsolationForest()
isolationForest10.setNumEstimators(100)
isolationForest10.setContamination(0.1)
isolationForest10.setFeaturesCol("indexedFeatures")
// isolationForest10.setContaminationError(0.1 * 0.01)

val isolationForestModel10 = isolationForest10.fit(dfCastImputedAssembledIndexed)
val scores10 = isolationForestModel10.transform(dfCastImputedAssembledIndexed)
```
scala> scores05.agg(sum("predictedLabel")).show()
+-------------------+
|sum(predictedLabel)|
+-------------------+
|               35.0|
+-------------------+


scala> scores10.agg(sum("predictedLabel")).show()
+-------------------+
|sum(predictedLabel)|
+-------------------+
|               70.0|
+-------------------+
```
