### PR TITLE
Added Scala version selection via build parameter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,39 @@
 # More details on how to configure the Travis build
 # https://docs.travis-ci.com/user/customizing-the-build/
 
+dist: trusty
+
 language: scala
-scala:
-  - 2.11.8
 
 jdk:
   - oraclejdk8
 
-#Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
+jobs:
+  include:
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.3.0 PERFORM_RELEASE=true  # Only one build should have PERFORM_RELEASE=true.
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.4.3 PERFORM_RELEASE=false
+    - scala: 2.12.11
+      env: SPARK_VERSION=2.4.3 PERFORM_RELEASE=false
+
+# Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step
 install:
   - true
 
-#Don't build tags
+# Don't build tags
 branches:
   except:
   - /^v\d/
 
-#Build and perform release (if needed)
+# Build and perform release (if needed).
+# Currently, only one build is released using Shipkit. Once Shipkit supports releasing multiple builds under the same
+# version, we will automatically publish the artifacts from all builds.
+# https://github.com/mockito/shipkit/issues/858
 script:
-  - ./gradlew build -s && ./gradlew ciPerformRelease
-
-dist: trusty
+  - if [ $PERFORM_RELEASE == true ]; then
+      ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
+    else
+      ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    fi

--- a/README.md
+++ b/README.md
@@ -31,10 +31,17 @@ It is recommended to use Scala 2.11.8 and Spark 2.3.0. To build, run the followi
 ```
 This will produce a jar file in the ``./isolation-forest/build/libs/`` directory.
 
-If you want to use the library with Spark 2.4, you can specify this when running the build command.
+If you want to use the library with Spark 2.4 (and the Scala 2.11.8 default), you can specify this when running the
+build command.
 
 ```bash
 ./gradlew build -PsparkVersion=2.4.3
+```
+
+You can also build an artifact with Spark 2.4 and Scala 2.12.
+
+```bash
+./gradlew build -PsparkVersion=2.4.3 -PscalaVersion=2.12.11
 ```
 
 ### Add an isolation-forest dependency to your project

--- a/isolation-forest/build.gradle
+++ b/isolation-forest/build.gradle
@@ -1,25 +1,29 @@
 import org.gradle.util.VersionNumber
 
 plugins {
-    // Apply the scala plugin to add support for Scala
     id 'scala'
 }
 
-def sparkVersion = findProperty("sparkVersion") ?: "2.3.0"
+def scalaVersion = findProperty("scalaVersion") ?: "2.11.8"  // Scala 2.11.8 is the default Scala build version.
+println "Scala version: " + scalaVersion
+// If scalaVersion == "2.11.8", then scalaVersionShort == "2.11".
+def scalaVersionShort = VersionNumber.parse(scalaVersion).getMajor() + "." + VersionNumber.parse(scalaVersion).getMinor()
 
+def sparkVersion = findProperty("sparkVersion") ?: "2.3.0"  // Spark 2.3.0 is the default Spark build version.
 println "Spark version: " + sparkVersion
 
 dependencies {
-    compile("com.chuusai:shapeless_2.11:2.3.2")
+    compile("com.chuusai:shapeless_" + scalaVersionShort + ":2.3.2")
     if(VersionNumber.parse(sparkVersion) >= VersionNumber.parse("2.4.0")) {
-        compile("org.apache.spark:spark-avro_2.11:" + sparkVersion)
-    } else { 
-        compile("com.databricks:spark-avro_2.11:4.0.0")
+        compile("org.apache.spark:spark-avro_" + scalaVersionShort + ":" + sparkVersion)
+    } else {
+        compile("com.databricks:spark-avro_" + scalaVersionShort + ":4.0.0")
     }
-    compile("org.apache.spark:spark-core_2.11:" + sparkVersion)
-    compile("org.apache.spark:spark-mllib_2.11:" + sparkVersion)
-    compile("org.apache.spark:spark-sql_2.11:" + sparkVersion)
-    compile("org.scalatest:scalatest_2.11:2.2.6")
+    compile("org.apache.spark:spark-core_" + scalaVersionShort + ":" + sparkVersion)
+    compile("org.apache.spark:spark-mllib_" + scalaVersionShort + ":" + sparkVersion)
+    compile("org.apache.spark:spark-sql_" + scalaVersionShort + ":" + sparkVersion)
+    compile("org.scala-lang:scala-library:" + scalaVersion)
+    compile("org.scalatest:scalatest_" + scalaVersionShort + ":3.1.0")
     compile("org.testng:testng:6.8.8")
 }
 
@@ -27,4 +31,4 @@ test {
     useTestNG()
 }
 
-archivesBaseName = "${project.name}_${sparkVersion}_2.11"
+archivesBaseName = "${project.name}_${sparkVersion}_${scalaVersionShort}"


### PR DESCRIPTION
I added the capability to specify the Scala build version using the build parameter scalaVersion. This will now allow us to build using Scala 2.12, which has been requested here: https://github.com/linkedin/isolation-forest/issues/14

Currently, only one build is released using Shipkit. Once Shipkit supports releasing multiple builds under the same version, we will automatically publish the artifacts from all builds. I submitted a request for this Shipkit enhancement a while back:

https://github.com/mockito/shipkit/issues/858

In the meantime, I still want Travis CI to build multiple versions with Spark 2.3.0, Spark 2.4.2, Scala 2.11, Scala 2.12, etc. to verify they all build successfully. I modified the .travis.yml file to achieve this. The builds are done in parallel:

https://travis-ci.org/github/linkedin/isolation-forest/builds/691178714