### PR TITLE
Now using Travis stages to test, upload artifacts, and publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-*/build
+build/
 .DS_Store
 .idea
 spark-warehouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,24 @@ jdk:
 
 jobs:
   include:
-    - stage: "Tests"
-    - script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    - stage: tests
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - scala: 2.11.8
       env: SPARK_VERSION=2.3.0
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-    - stage: "Upload"
-    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    - stage: upload
+      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - scala: 2.11.8
       env: SPARK_VERSION=2.3.0
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-    - stage: "Release"
-    - script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
+    - stage: release
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
     - scala: 2.11.8
       env: SPARK_VERSION=2.3.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,27 @@ dist: trusty
 
 language: scala
 
+scala:
+  - 2.11.8
+  - 2.12.11
+
+env:
+  - SPARK_VERSION=2.3.0
+  - SPARK_VERSION=2.4.3
+
 jdk:
   - oraclejdk8
 
 jobs:
+  exclude:
+    - scala: 2.12.11
+      env: SPARK_VERSION=2.3.0
   include:
     - stage: tests
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
-    - scala: 2.11.8
-      env: SPARK_VERSION=2.3.0
-    - scala: 2.11.8
-      env: SPARK_VERSION=2.4.3
-    - scala: 2.12.11
-      env: SPARK_VERSION=2.4.3
-    - stage: upload
-      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
-    - scala: 2.11.8
-      env: SPARK_VERSION=2.3.0
-    - scala: 2.11.8
-      env: SPARK_VERSION=2.4.3
-    - scala: 2.12.11
-      env: SPARK_VERSION=2.4.3
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
-    - scala: 2.11.8
+      scala: 2.11.8
       env: SPARK_VERSION=2.3.0
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
     - scala: 2.12.11
       env: SPARK_VERSION=2.3.0
   include:
-    - stage: tests
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,21 @@ jobs:
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
     - stage: upload
-      if: branch = master
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
+      if: branch = master
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
+      if: branch = master
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-    - stage: release
       if: branch = master
+    - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
+      if: branch = master
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,32 +8,35 @@ language: scala
 jdk:
   - oraclejdk8
 
-script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
-
 jobs:
   include:
     - scala: 2.11.8
       env: SPARK_VERSION=2.3.0
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - stage: upload
-      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
-      if: branch = master
+      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+#      if: branch = master
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
-      if: branch = master
+      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+#      if: branch = master
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-      if: branch = master
+      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+#      if: branch = master
     - stage: release
-      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
-      if: branch = master
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
+#      if: branch = master
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,19 @@ dist: trusty
 
 language: scala
 
-scala:
-  - 2.11.8
-  - 2.12.11
-
-env:
-  - SPARK_VERSION=2.3.0
-  - SPARK_VERSION=2.4.3
-
 jdk:
   - oraclejdk8
 
+script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+
 jobs:
-  exclude:
-    - scala: 2.12.11
-      env: SPARK_VERSION=2.3.0
   include:
-    - stage: test
-      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.3.0
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.4.3
+    - scala: 2.12.11
+      env: SPARK_VERSION=2.4.3
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
       scala: 2.11.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,12 @@ jobs:
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
     - stage: publish
-    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
-    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-      scala: 2.11.8
+    - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
-    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-      scala: 2.12.11
+    - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,14 @@ jobs:
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
     - stage: publish
-      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-    - scala: 2.11.8
+    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+      scala: 2.11.8
       env: SPARK_VERSION=2.3.0
-    - scala: 2.11.8
+    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+      scala: 2.11.8
       env: SPARK_VERSION=2.4.3
-    - scala: 2.12.11
+    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+      scala: 2.12.11
       env: SPARK_VERSION=2.4.3
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,20 +23,20 @@ jobs:
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-      if: branch = master
+      if: (branch = master) AND NOT (type = pull_request)
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-      if: branch = master
+      if: (branch = master) AND NOT (type = pull_request)
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-      if: branch = master
+      if: (branch = master) AND NOT (type = pull_request)
     - stage: release
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
-      if: branch = master
+      if: (branch = master) AND NOT (type = pull_request)
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,26 @@ jdk:
 
 jobs:
   include:
+    - stage: "Tests"
+    - script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - scala: 2.11.8
-      env: SPARK_VERSION=2.3.0 PERFORM_RELEASE=true  # Only one build should have PERFORM_RELEASE=true.
+      env: SPARK_VERSION=2.3.0
     - scala: 2.11.8
-      env: SPARK_VERSION=2.4.3 PERFORM_RELEASE=false
+      env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
-      env: SPARK_VERSION=2.4.3 PERFORM_RELEASE=false
+      env: SPARK_VERSION=2.4.3
+    - stage: "Upload"
+    - script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.3.0
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.4.3
+    - scala: 2.12.11
+      env: SPARK_VERSION=2.4.3
+    - stage: "Release"
+    - script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.3.0
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step
@@ -25,15 +39,4 @@ install:
 # Don't build tags
 branches:
   except:
-  - /^v\d/
-
-# Build and perform release (if needed).
-# Currently, only one build is released using Shipkit. Once Shipkit supports releasing multiple builds under the same
-# version, we will automatically publish the artifacts from all builds.
-# https://github.com/mockito/shipkit/issues/858
-script:
-  - if [ $PERFORM_RELEASE == true ]; then
-      ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
-    else
-      ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
-    fi
+    - /^v\d/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ jobs:
       env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
+    - stage: publish
+      script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.3.0
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.4.3
+    - scala: 2.12.11
+      env: SPARK_VERSION=2.4.3
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
       scala: 2.11.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ jobs:
       env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-    - stage: publish
+    - stage: upload
+      if: branch = master
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
@@ -27,6 +28,7 @@ jobs:
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
     - stage: release
+      if: branch = master
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,20 +23,20 @@ jobs:
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-#      if: branch = master
+      if: branch = master
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-#      if: branch = master
+      if: branch = master
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
       script: ./gradlew bintrayUpload -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-#      if: branch = master
+      if: branch = master
     - stage: release
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
-#      if: branch = master
+      if: branch = master
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
     - scala: 2.12.11
       env: SPARK_VERSION=2.3.0
   include:
+    - stage: test
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - stage: release
       script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;

--- a/build/shipkit/all-contributors.json
+++ b/build/shipkit/all-contributors.json
@@ -1,1 +1,0 @@
-[{ "name": "James Verbus", "login": "jverbus", "profileUrl": "https:\/\/github.com\/jverbus", "numberOfContributions": "1" }]


### PR DESCRIPTION
Using Travis stages in this way ensures that all build versions are successful before we publish any artifacts. This is in contrast to the previous version where it was possible, but unlikely, for a new version to be published for the baseline dependencies (Spark 2.3.0 and Scala 2.11.8), even if another build using different Spark/Scala versions failed.

**New build pipeline using Travis stages**

The first "test" stage runs all build variations in parallel to ensure they succeed.

The second "upload" stage is a kludge to work around a limitation of Shipkit: https://github.com/mockito/shipkit/issues/858. This second stage uploads all artifacts using the current project version defined in `version.properties`. This only runs if the code has been merged into the master branch.

The third "release" stage runs the Shipkit `ciPerformRelease` command. This (sadly, but inconsequently) re-uploads the baseline (Spark 2.3.0 and Scala 2.11.8) artifact, but it also pushes another commit to the GitHub repo adding version documentation, bumps the version in the `version.properties` file, and creates a git tag with the version number. This only runs if the code has been merged into the master branch.

**Testing**

I did some testing to verify the new stages definitions work. Here is a successful run when on a non-master branch:

https://travis-ci.org/github/linkedin/isolation-forest/builds/691611286

One can see only the "test" stage jobs run.

Here is a run (intentionally killed) that simulates the stages when on master:

https://travis-ci.org/github/linkedin/isolation-forest/builds/691610972

As you can see, the test and upload stages have three jobs as expected, and the release stage has one job.

We won't be able to actually validate with a proper release until it is merged to master.