### PR TITLE
Updated Travis CI config to use multiple stages for CI/CD.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
 .gradle
-*/build
+build/
 .DS_Store
 .idea
 spark-warehouse
 *.ipr
 *.iml
 *.iws
-
-isolation-forest/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,20 @@ language: scala
 jdk:
   - oraclejdk8
 
+script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+
 jobs:
   include:
     - scala: 2.11.8
-      env: SPARK_VERSION=2.3.0 PERFORM_RELEASE=true  # Only one build should have PERFORM_RELEASE=true.
+      env: SPARK_VERSION=2.3.0
     - scala: 2.11.8
-      env: SPARK_VERSION=2.4.3 PERFORM_RELEASE=false
+      env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
-      env: SPARK_VERSION=2.4.3 PERFORM_RELEASE=false
+      env: SPARK_VERSION=2.4.3
+    - stage: release
+      scala: 2.11.8
+      env: SPARK_VERSION=2.3.0
+      script: ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
 
 # Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step
@@ -25,15 +31,4 @@ install:
 # Don't build tags
 branches:
   except:
-  - /^v\d/
-
-# Build and perform release (if needed).
-# Currently, only one build is released using Shipkit. Once Shipkit supports releasing multiple builds under the same
-# version, we will automatically publish the artifacts from all builds.
-# https://github.com/mockito/shipkit/issues/858
-script:
-  - if [ $PERFORM_RELEASE == true ]; then
-      ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION && ./gradlew ciPerformRelease;
-    else
-      ./gradlew build -s -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
-    fi
+    - /^v\d/

--- a/build/shipkit/all-contributors.json
+++ b/build/shipkit/all-contributors.json
@@ -1,1 +1,0 @@
-[{ "name": "James Verbus", "login": "jverbus", "profileUrl": "https:\/\/github.com\/jverbus", "numberOfContributions": "1" }]


### PR DESCRIPTION
Using Travis stages in this way ensures that all build versions are
successful before we publish any artifacts. This is in contrast to the
previous version where it was possible, but unlikely, for a new version
to be published for the baseline dependencies (Spark 2.3.0 and Scala
2.11.8), even if another build using different Spark/Scala versions
failed.

**New build pipeline using Travis stages**

The first "test" stage runs all build variations in parallel to ensure they succeed.

The second "release" stage runs the Shipkit ciPerformRelease command. This uploads the new baseline (Spark 2.3.0 and Scala 2.11.8) artifact to JCenter, pushes another commit to the GitHub repo adding version documentation, bumps the version in the version.properties file, and creates a git tag with the version number.

**Other minor changes**

I updated the .gitignore and deleted some old build files that accidentally got committed in the past.