### PR TITLE
Added upload Travis CI stage that pushes artifacts for all build variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,19 @@ jobs:
     - stage: upload
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
-      script: ./gradlew releaseNeeded | grep -q "Releasing"
+      script: ./gradlew releaseNeeded | grep "Releasing"
         && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-        || true;
+        || echo "No release needed.";
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
-      script: ./gradlew releaseNeeded | grep -q "Releasing"
+      script: ./gradlew releaseNeeded | grep "Releasing"
         && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-        || true;
+        || echo "No release needed.";
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-      script: ./gradlew releaseNeeded | grep -q "Releasing"
+      script: ./gradlew releaseNeeded | grep "Releasing"
         && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
-        || true;
+        || echo "No release needed.";
     - stage: release
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,24 @@ jobs:
       env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
+    # The upload stage is an inelegant way to automatically publish all artifact variants until the following Shipkit
+    # issue is resolved: https://github.com/mockito/shipkit/issues/858
     - stage: upload
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0
-      script: ./gradlew releaseNeeded | grep -q "Skipping release because publications are identical."
-        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+      script: ./gradlew releaseNeeded | grep -q "Releasing"
+        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+        || true;
     - scala: 2.11.8
       env: SPARK_VERSION=2.4.3
-      script: ./gradlew releaseNeeded | grep -q "Skipping release because publications are identical."
-        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+      script: ./gradlew releaseNeeded | grep -q "Releasing"
+        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+        || true;
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
-      script: ./gradlew releaseNeeded | grep -q "Skipping release because publications are identical."
-        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+      script: ./gradlew releaseNeeded | grep -q "Releasing"
+        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION
+        || true;
     - stage: release
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,19 @@ jobs:
       env: SPARK_VERSION=2.4.3
     - scala: 2.12.11
       env: SPARK_VERSION=2.4.3
+    - stage: upload
+      scala: 2.11.8
+      env: SPARK_VERSION=2.3.0
+      script: ./gradlew releaseNeeded | grep -q "Skipping release because publications are identical."
+        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    - scala: 2.11.8
+      env: SPARK_VERSION=2.4.3
+      script: ./gradlew releaseNeeded | grep -q "Skipping release because publications are identical."
+        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
+    - scala: 2.12.11
+      env: SPARK_VERSION=2.4.3
+      script: ./gradlew releaseNeeded | grep -q "Skipping release because publications are identical."
+        && ./gradlew bintrayUpload -PscalaVersion=$TRAVIS_SCALA_VERSION -PsparkVersion=$SPARK_VERSION;
     - stage: release
       scala: 2.11.8
       env: SPARK_VERSION=2.3.0


### PR DESCRIPTION
I added an "upload" Travis CI stage that runs before the "release" stage.

For each build variant in parallel... The "upload" stage checks if a release is needed using the Shipkit `releaseNeeded` command. If the result indicates a release is needed, then the artifacts are uploaded to Bintray using the current version number.

The following "release" stage runs the normal Shipkit release process, which can only upload one artifact. This stage does make a following commit to the git repo with release docs, bumps the version in the `version.properties` file, and creates a git tag.