### PR TITLE
Removed build for Scala 2.11.12.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - scala-version: 2.11.12
-            spark-version: 2.4.3
           - scala-version: 2.12.18
             spark-version: 2.4.3
           - scala-version: 2.12.18


### PR DESCRIPTION
No longer support Scala 2.11 as the latest maintenance release was November 9, 2017: https://www.scala-lang.org/download/2.11.0.html

This commit is in preparation for another commit with larger changes that no longer support Scala 2.11. https://github.com/linkedin/isolation-forest/pull/48