### PR TITLE
Removed test dependencies from compile classpath. Updated build.gradle dependencies. No longer support Scala 2.11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             spark-version: 3.1.3
           - scala-version: 2.12.19
             spark-version: 3.2.4
-          - scala-version: 2.13.11
+          - scala-version: 2.13.14
             spark-version: 3.2.4
           - scala-version: 2.12.19
             spark-version: 3.3.4
@@ -41,7 +41,7 @@ jobs:
             spark-version: 3.4.3
           - scala-version: 2.12.19
             spark-version: 3.5.1
-          - scala-version: 2.13.14
+          - scala-version: 2.13.14s
             spark-version: 3.5.1
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             spark-version: 3.4.3
           - scala-version: 2.12.19
             spark-version: 3.5.1
-          - scala-version: 2.13.14s
+          - scala-version: 2.13.14
             spark-version: 3.5.1
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,28 +21,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - scala-version: 2.12.18
+          - scala-version: 2.12.19
             spark-version: 2.4.3
-          - scala-version: 2.12.18
-            spark-version: 3.0.0
-          - scala-version: 2.12.18
-            spark-version: 3.1.1
-          - scala-version: 2.12.18
+          - scala-version: 2.12.19
+            spark-version: 3.0.3
+          - scala-version: 2.12.19
+            spark-version: 3.1.3
+          - scala-version: 2.12.19
             spark-version: 3.2.4
           - scala-version: 2.13.11
             spark-version: 3.2.4
-          - scala-version: 2.12.18
-            spark-version: 3.3.3
-          - scala-version: 2.13.12
-            spark-version: 3.3.3
-          - scala-version: 2.12.18
-            spark-version: 3.4.2
-          - scala-version: 2.13.12
-            spark-version: 3.4.2
-          - scala-version: 2.12.18
-            spark-version: 3.5.0
-          - scala-version: 2.13.12
-            spark-version: 3.5.0
+          - scala-version: 2.12.19
+            spark-version: 3.3.4
+          - scala-version: 2.13.14
+            spark-version: 3.3.4
+          - scala-version: 2.12.19
+            spark-version: 3.4.3
+          - scala-version: 2.13.14
+            spark-version: 3.4.3
+          - scala-version: 2.12.19
+            spark-version: 3.5.1
+          - scala-version: 2.13.14
+            spark-version: 3.5.1
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     steps:
       - name: Check out code

--- a/isolation-forest/build.gradle
+++ b/isolation-forest/build.gradle
@@ -4,27 +4,23 @@ plugins {
     id 'scala'
 }
 
-def scalaVersion = findProperty("scalaVersion") ?: "2.13.12"
+def scalaVersion = findProperty("scalaVersion") ?: "2.13.14"
 println "Scala version: " + scalaVersion
-// If scalaVersion == "2.11.8", then scalaVersionShort == "2.11".
+// If scalaVersion == "X.Y.Z", then scalaVersionShort == "X.Y".
 def scalaVersionShort = VersionNumber.parse(scalaVersion).getMajor() + "." + VersionNumber.parse(scalaVersion).getMinor()
 
-def sparkVersion = findProperty("sparkVersion") ?: "3.4.1"
+def sparkVersion = findProperty("sparkVersion") ?: "3.5.1"
 println "Spark version: " + sparkVersion
 
 dependencies {
-    compile("com.chuusai:shapeless_" + scalaVersionShort + ":2.3.10")
-    if(VersionNumber.parse(sparkVersion) >= VersionNumber.parse("2.4.0")) {
-        compile("org.apache.spark:spark-avro_" + scalaVersionShort + ":" + sparkVersion)
-    } else {
-        compile("com.databricks:spark-avro_" + scalaVersionShort + ":4.0.0")
-    }
-    compile("org.apache.spark:spark-core_" + scalaVersionShort + ":" + sparkVersion)
-    compile("org.apache.spark:spark-mllib_" + scalaVersionShort + ":" + sparkVersion)
-    compile("org.apache.spark:spark-sql_" + scalaVersionShort + ":" + sparkVersion)
-    compile("org.scala-lang:scala-library:" + scalaVersion)
-    compile("org.scalatest:scalatest_" + scalaVersionShort + ":3.1.0")
-    compile("org.testng:testng:6.8.8")
+    implementation("com.chuusai:shapeless_" + scalaVersionShort + ":2.3.12")
+    implementation("org.apache.spark:spark-avro_" + scalaVersionShort + ":" + sparkVersion)
+    implementation("org.apache.spark:spark-core_" + scalaVersionShort + ":" + sparkVersion)
+    implementation("org.apache.spark:spark-mllib_" + scalaVersionShort + ":" + sparkVersion)
+    implementation("org.apache.spark:spark-sql_" + scalaVersionShort + ":" + sparkVersion)
+    implementation("org.scala-lang:scala-library:" + scalaVersion)
+    testImplementation("org.scalatest:scalatest_" + scalaVersionShort + ":3.2.18")
+    testImplementation("org.testng:testng:7.5.1")
 }
 
 test {

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version of the produced binaries.
 # The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version).
-version=3.0.*
+version=3.1.*


### PR DESCRIPTION
Removed test dependencies from the compile classpath. Updated build.gradle dependencies to clean up build scan. These changes fixed the issue reported here: https://github.com/linkedin/isolation-forest/issues/47

No longer support Scala 2.11 as the latest maintenance release was November 9, 2017: https://www.scala-lang.org/download/2.11.0.html