### PR TITLE
Made minor edits to match the proposed Estimator transformSchema mehtod to the existing Model transformSchema method.

### DIFF
--- a/isolation-forest/src/main/scala/com/linkedin/relevance/isolationforest/IsolationForestModel.scala
+++ b/isolation-forest/src/main/scala/com/linkedin/relevance/isolationforest/IsolationForestModel.scala
@@ -89,9 +89,9 @@ class IsolationForestModel(
 
   /**
     * Validates the input schema and transforms it into the output schema. It validates that the
-    * input DataFrame has a $(featuresCol) of the correct type.  It also ensures that the input
-    * DataFrame does not already have $(predictionCol) or $(scoreCol) columns, as they will be
-    * created during the fitting process.
+    * input DataFrame has a $(featuresCol) of the correct type and appends the output columns to
+    * the input schema. It also ensures that the input DataFrame does not already have
+    * $(predictionCol) or $(scoreCol) columns, as they will be created during the fitting process.
     *
     * @param schema The schema of the DataFrame containing the data to be fit.
     * @return The schema of the DataFrame containing the data to be fit, with the additional


### PR DESCRIPTION
Small edits on top of https://github.com/linkedin/isolation-forest/pull/60.

In particular:

Includes checks and schema modifications similar to what was already done in the Model class. Both the Estimator and the Model will:
- Validate that the featuresCol exists and is of the correct type.
- Verify that the predictionCol and scoreCol do not already exist in the input schema.
- Append predictionCol and scoreCol to the schema.

This ensures that the Estimator’s schema transformation is consistent with the eventual Model’s schema, making it clear to downstream pipeline stages what the final output schema will be.

The PR code adds explicit checks that the predictionCol and scoreCol do not already exist. This is a good safeguard to prevent accidental overwrites of existing columns. 