### PR TITLE
Refactor distribution usage in BaggedPoint and add new edge-case tests

### DIFF
--- a/isolation-forest/src/test/scala/com/linkedin/relevance/isolationforest/BaggedPointTest.scala
+++ b/isolation-forest/src/test/scala/com/linkedin/relevance/isolationforest/BaggedPointTest.scala
@@ -175,7 +175,7 @@ class BaggedPointTest {
 
     val expectedSumArray = expectedResult.map(x => x._1 + x._2.features.sum).sorted
     val actualSumArray = flattenedBaggedPointArray.map(x => x._1 + x._2.features.sum).sorted
-    Assert.assertEquals(expectedSumArray.toSeq, actualSumArray.toSeq) 
+    Assert.assertEquals(expectedSumArray.toSeq, actualSumArray.toSeq)
   }
 
   @Test(description = "flattenBaggedRDDNonIntegerWeightTest")
@@ -203,5 +203,85 @@ class BaggedPointTest {
     Assert.assertTrue(result2 === subsampleWeights(1) * numRecords +- numRecords * tol,
       s"expected ${subsampleWeights(1) * numRecords} +/- ${numRecords * tol}, but observed" +
         s" ${result2}")
+  }
+
+  @Test(description = "baggedPointEmptyRDDTest")
+  def baggedPointEmptyRDDTest(): Unit = {
+    val spark = getSparkSession
+    // Create an empty RDD of DataPoint
+    val emptyRDD = spark.sparkContext.emptyRDD[DataPoint]
+
+    // Attempt to create a bagged RDD from an empty input
+    val baggedRDD = BaggedPoint.convertToBaggedRDD(emptyRDD, 0.5, 5, withReplacement = true, 42L)
+
+    // We expect no output
+    Assert.assertEquals(baggedRDD.count(), 0L, "Bagged RDD should be empty when input is empty.")
+  }
+
+  @Test(description = "baggedPointSingleRecordTest")
+  def baggedPointSingleRecordTest(): Unit = {
+    val spark = getSparkSession
+    // Generate exactly one DataPoint
+    val singleDataPoint = generateDataPoints(numFeatures = 3, numInstances = 1)
+    val rdd = spark.sparkContext.parallelize(singleDataPoint.toIndexedSeq, numSlices = 1)
+
+    // Subsample with a small rate, multiple subsamples, no replacement
+    val baggedRDD = BaggedPoint.convertToBaggedRDD(rdd, subsamplingRate = 0.5, numSubsamples = 3, withReplacement = false, seed = 100L)
+
+    // There should be exactly one BaggedPoint in the result
+    Assert.assertEquals(baggedRDD.count(), 1L, "Expected exactly 1 bagged point for single-record RDD.")
+
+    // Flatten and see how many copies appear
+    val flattened = BaggedPoint.flattenBaggedRDD(baggedRDD, seed = 100L).collect()
+    // Because it's Binomial(1, 0.5) for 3 subsamples, we expect an integer between 0 and 3 total.
+    Assert.assertTrue(flattened.length >= 0 && flattened.length <= 3,
+      s"Flattened length should be between 0 and 3, found ${flattened.length}.")
+  }
+
+  @Test(description = "baggedPointVerySmallSubsamplingRateTest")
+  def baggedPointVerySmallSubsamplingRateTest(): Unit = {
+    val spark = getSparkSession
+    // Generate some data
+    val data = generateDataPoints(numFeatures = 1, numInstances = 2000)
+    val rdd = spark.sparkContext.parallelize(data.toIndexedSeq)
+
+    // Use a very small subsampling rate
+    val verySmallRate = 0.001
+    val baggedRDD = BaggedPoint.convertToBaggedRDD(rdd, verySmallRate, numSubsamples = 5, withReplacement = true, seed = 9999L)
+
+    // Collect subsample weights
+    val subsampleWeights: Array[Array[Double]] = baggedRDD.map(_.subsampleWeights).collect()
+
+    // Optional: We can do a rough check that the average is near the Poisson mean of 0.001 for each subsample
+    // Reuse your existing testRandomArrays if you like, or do a simpler sanity check:
+    val meanWeights = subsampleWeights.flatten.sum / subsampleWeights.flatten.length
+    Assert.assertTrue(math.abs(meanWeights - verySmallRate) < 0.0005,
+      s"Mean weight $meanWeights should be near $verySmallRate for a very small sampling rate.")
+  }
+
+  @Test(description = "baggedPointConsistencyOfResultsTest")
+  def baggedPointConsistencyOfResultsTest(): Unit = {
+    val spark = getSparkSession
+    val data = generateDataPoints(numFeatures = 2, numInstances = 100)
+    val rdd = spark.sparkContext.parallelize(data.toIndexedSeq)
+
+    // We run convertToBaggedRDD twice with the same seed and compare
+    val seed = 2020L
+    val baggedRDD1 = BaggedPoint.convertToBaggedRDD(rdd, subsamplingRate = 0.3, numSubsamples = 5, withReplacement = true, seed)
+    val baggedRDD2 = BaggedPoint.convertToBaggedRDD(rdd, subsamplingRate = 0.3, numSubsamples = 5, withReplacement = true, seed)
+
+    // Collect the results
+    val arr1 = baggedRDD1.map(_.subsampleWeights).collect()
+    val arr2 = baggedRDD2.map(_.subsampleWeights).collect()
+
+    // They should be the same length
+    Assert.assertEquals(arr1.length, arr2.length, "Both runs should produce the same number of BaggedPoints.")
+
+    // Compare them element-wise to ensure they match
+    // (We expect EXACT match because same seed => same distribution draws)
+    for(i <- arr1.indices) {
+      Assert.assertEquals(arr1(i), arr2(i),
+        s"Mismatch in subsampleWeights for record $i with the same seed = $seed.")
+    }
   }
 }


### PR DESCRIPTION
## Summary

This pull request refactors `BaggedPoint` and adds several tests to cover edge cases and ensure consistent behavior. The changes help ensure each Spark partition receives a fresh random state, eliminate concurrency issues, and broaden test coverage to strengthen confidence in the implementation.

---

## Changes

1. **Refactor Distribution Usage**
   - Introduces **factory functions** (`poissonFactory`, `binomialFactory`) for creating Poisson and Binomial distributions.  
   - Each partition now receives its own random state, which is reseeded via a **partition-specific seed**, improving reproducibility.

2. **Private Helper Method**
   - The method for converting an input dataset into a `BaggedPoint` representation (`convertToBaggedRDDHelper`) is now **private** instead of in a nested scope, making the code more readable and maintainable.

3. **Flatten Method Update**
   - In `flattenBaggedRDD`, a **per-partition `Random`** instance is created for rounding floating-point weights to integers.  
   - Ensures no shared mutable state is used across partitions, improving determinism and clarity.

4. **Additional Tests**
   - **Empty RDD Test** (`baggedPointEmptyRDDTest`): Verifies that an empty input RDD produces an empty output.  
   - **Single-Record RDD Test** (`baggedPointSingleRecordTest`): Confirms correct handling of a single data point.  
   - **Very Small Subsampling Rate** (`baggedPointVerySmallSubsamplingRateTest`): Checks behavior for near-zero sampling fractions.  
   - **Consistency/Determinism** (`baggedPointConsistencyOfResultsTest`): Ensures identical outputs for identical seeds.  
---

## Motivation and Benefits

- **Partition-Safe RNG Usage**: Each partition independently initializes a random distribution, avoiding concurrency or determinism issues from shared state.  
- **Clearer Code Structure**: Moving distribution creation into a **factory pattern** and making helper functions private leads to more modular, testable code.  
- **Extended Test Coverage**: New edge-case tests (empty RDD, single-record, very small sampling rate, deterministic seeding) increase robustness and confidence in the library’s behavior.  

---

## Testing

- Existing tests remain **unchanged** and pass as before.  
- New tests confirm correct handling for:
  - Empty RDDs  
  - Single-record input  
  - Very small sampling rates  
  - Deterministic results using the same seed  

---

## Validation - Isolation Forest AUROC Comparison

| **Dataset**         | **From Liu et al. (2008)** | **This Library - Old Run**<br>(2019) | **This Library - New Run**<br>(Current)         | **Notes**                                                     |
|---------------------|----------------------------|------------------------------------|----------------------------------|---------------------------------------------------------------|
| **Http (KDDCUP99)** | **1.00**                  | 0.99973 ± 0.00007                  | 0.99973 ± 0.00007                | identical.                                                |
| **ForestCover**     | **0.88**                  | 0.903 ± 0.005                      | 0.904 ± 0.005                  | Matches within 1-sigma.                                          |
| **Mulcross**        | **0.97**                  | 0.9926 ± 0.0006                    | 0.9918 ± 0.0005                | Matches within 2-sigma.                                    |
| **Smtp (KDDCUP99)** | **0.88**                  | 0.907 ± 0.001                      | 0.9075 ± 0.0014                  | Matches within 1-sigma.                                         |
| **Shuttle**         | **1.00**                  | 0.9974 ± 0.0014                    | 0.99728 ± 0.00013                | Matches within 1-sigma.         |
| **Mammography**     | **0.86**                  | 0.8636 ± 0.0015                    | 0.86362 ± 0.0015                | Matches within 1-sigma.                                         |
| **Annthyroid**      | **0.82**                  | 0.815 ± 0.006                      | 0.815 ± 0.006                  | Identical.                                        |
| **Satellite**       | **0.71**                  | 0.709 ± 0.004                      | 0.709 ± 0.004                  | Identical.                                             |
| **Pima**            | **0.67**                  | 0.651 ± 0.003                      | 0.651 ± 0.003                  | Identical.                                                |
| **Breastw**         | **0.99**                  | 0.9862 ± 0.0003                    | 0.9863 ± 0.0003                | Matches within 1-sigma.                                    |
| **Arrhythmia**      | **0.80**                  | 0.804 ± 0.002                      | 0.805 ± 0.002                | Matches within 1-sigma.                                      |
| **Ionosphere**      | **0.85**                  | 0.8481 ± 0.0002                    | 0.8481 ± 0.0002                 | Identical.                                             |

### Conclusion

The library’s IsolationForest implementation matches both the original Isolation Forest paper’s reported AUROCs and the previous run of the same library from 2019. Minor discrepancies are well within expected variance for randomized algorithms and floating-point arithmetic.





