### PR TITLE
build(ci): migrate publishing off EOL OSSRH; bump ORT wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
         env:
           SCALA_VERSION: ${{ matrix.scala-version }}
           SPARK_VERSION: ${{ matrix.spark-version }}
-          SONATYPE_TOKEN_USER: ${{ secrets.SONATYPE_TOKEN_USER }}
-          SONATYPE_TOKEN_PWD: ${{ secrets.SONATYPE_TOKEN_PWD }}
+          SONATYPE_PORTAL_TOKEN_USER: ${{ secrets.SONATYPE_PORTAL_TOKEN_USER }}
+          SONATYPE_PORTAL_TOKEN_PWD: ${{ secrets.SONATYPE_PORTAL_TOKEN_PWD }}
           PGP_KEY: ${{ secrets.PGP_KEY }}
           PGP_PWD: ${{ secrets.PGP_PWD }}
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -32,8 +32,10 @@ apply plugin: "io.github.gradle-nexus.publish-plugin"  // https://github.com/gra
 nexusPublishing {
     repositories {
         sonatype {
-            username = System.getenv("SONATYPE_TOKEN_USER")
-            password = System.getenv("SONATYPE_TOKEN_PWD")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username = System.getenv("SONATYPE_PORTAL_TOKEN_USER")
+            password = System.getenv("SONATYPE_PORTAL_TOKEN_PWD")
         }
     }
 

--- a/isolation-forest-onnx/requirements.txt
+++ b/isolation-forest-onnx/requirements.txt
@@ -1,5 +1,5 @@
 avro-python3==1.9.1
 numpy==1.26.4
 onnx==1.17.0
-onnxruntime==1.18.0
+onnxruntime==1.22.0
 protobuf==5.29.5


### PR DESCRIPTION
The old OSSRH host (https://oss.sonatype.org/) is shutting down **on 30 June 2025** – banner text:
“The OSSRH service will reach end‑of‑life on June 30th 2025. Learn more about how to transfer to the Central Publishing Portal here.”

Publishing jobs were failing because the legacy Nexus REST API now returns **403 Forbidden**.
This commit moves us to Sonatype’s transitional *OSSRH‑Staging API* that front‑ends the new Central Publishing Portal:

* `gradle/release.gradle`
  * sets `nexusUrl` → `https://ossrh‑staging-api.central.sonatype.com/service/local/`
  * sets `snapshotRepositoryUrl` → `https://central.sonatype.com/repository/maven-snapshots/`
  * switches credentials to **Central Portal** tokens (`SONATYPE_PORTAL_TOKEN_USER / PWD`).

* `.github/workflows/ci.yml`
  * passes the new secret names to the “Release to Maven Central” step.

This retains the existing
`publishToSonatype closeAndReleaseStagingRepository` flow. **Future work:** migrate completely to the Portal’s native publish API and drop the staging bridge.

Additional drive‑by fix
-----------------------
* `isolation-forest-onnx/requirements.txt` – bump `onnxruntime` → **1.22.0** (universal2 wheel) to restore Apple‑silicon test coverage.